### PR TITLE
Add links to old issues in the page footer

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -264,6 +264,26 @@ const Footer = () => {
 							</p>
 						</div>
 						<div id={styles.cell}>
+							<h3 id={styles.department}>
+								Want to see past articles?
+							</h3>
+							<div className={`${styles.dropdown}`}>
+								<button className={styles.dropbtn}>
+								Issues
+								</button>
+								<div id={styles.dropDownContent}>
+									{[...Array(13)].map((_, index) => {
+										const i = 13 - index;
+										return (
+										<div key={i}>
+											<Link href={`/volume/113/issue/${i}`}>Issue {i}</Link>
+										</div>
+										);
+									})}
+								</div>
+							</div>
+						</div>
+						<div id={styles.cell}>
 							<h3
 								id={styles.department}
 								className={styles.virtualArchives}

--- a/styles/Footer.module.css
+++ b/styles/Footer.module.css
@@ -154,3 +154,16 @@
 		justify-self: start;
 	}
 }
+.dropbtn {
+	background-color: #3c3c3c;
+	color: white;
+	padding: 16px;
+	font-size: 16px;
+	border: none;
+  }
+
+  .dropDownContent a:hover {background-color: #ddd;}
+  
+  .dropdown:hover .dropDownContent {display:block;}
+  
+  .dropdown:hover .dropbtn {background-color: #8c8c8c;}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -132,3 +132,20 @@ a {
 .discrete-link:focus {
 	text-decoration-color: var(--accent);
 }
+
+div#Footer_dropDownContent__500B8 {
+	display: block;
+	min-width: 160px;
+	box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+	z-index: 1;
+}
+
+div#Footer_dropDownContent__500B8 a {
+	text-decoration: none;
+	display:block;
+	padding: 5px;
+}
+
+div#Footer_dropDownContent__500B8 a:hover {background-color: #ddd;}
+
+.Footer_dropdown__d7nLj:hover .Footer_dropDownContent__500B8 {display:block;}


### PR DESCRIPTION
In the footer of every page there are links to the pages of previous issues. For some reason, the dropdown menu wouldn't work on hover, so I just left it as it was. I'm not sure why it wasn't working, my CSS seemed correct.