### PR TITLE
Change Preview Image Opening 

### DIFF
--- a/components/LatestPreviewImage.tsx
+++ b/components/LatestPreviewImage.tsx
@@ -19,7 +19,9 @@ const LatestPreviewImage = (props: { imageClass: any; imageIndex: number }) => {
 	return (
 		<Link
 			passHref
-			href={(data && data.link) || "https://issuu.com/stuyspectator"} target="_blank"
+			href={(data && data.link) || "https://issuu.com/stuyspectator"}
+			target="_blank"
+			rel="noopener"
 		>
 			<img
 				alt={`The ${

--- a/components/LatestPreviewImage.tsx
+++ b/components/LatestPreviewImage.tsx
@@ -19,7 +19,7 @@ const LatestPreviewImage = (props: { imageClass: any; imageIndex: number }) => {
 	return (
 		<Link
 			passHref
-			href={(data && data.link) || "https://issuu.com/stuyspectator"}
+			href={(data && data.link) || "https://issuu.com/stuyspectator"} target="_blank"
 		>
 			<img
 				alt={`The ${


### PR DESCRIPTION
Changed PreviewImage.tsx so that when you click on the preview image, it opens the link on a new page instead of opening it on the current page.