### PR TITLE
Styling Staff Page

### DIFF
--- a/pages/about/staff.tsx
+++ b/pages/about/staff.tsx
@@ -15,9 +15,9 @@ function StaffPage() {
 			<main id={styles.main}>
 				<h1>Members of the 2023-2024 Spectator Editorial Board</h1>
 				<section id={styles.departments}>
-				<p className={styles.special_def}>* Managing Board</p>
-				<p className={styles.special_def}>** Editors-in-Training</p>
-				
+					<p className={styles.special_def}>* Managing Board</p>
+					<p className={styles.special_def}>** Editors-in-Training</p>
+
 					<div>
 						<h3 className={styles.EIC}>Editors In Chief</h3>
 						<p>Rebecca Bao*</p>
@@ -53,7 +53,7 @@ function StaffPage() {
 						<p>Jovanna Wu</p>
 					</div>
 					<div>
-						<h3 className ={styles.ae}>Arts & Entertainment Editors</h3>
+						<h3 className={styles.ae}>Arts & Entertainment Editors</h3>
 						<p>Lucien Clough</p>
 						<p>Simone Raleigh</p>
 						<p>Santino Suarez</p>

--- a/pages/about/staff.tsx
+++ b/pages/about/staff.tsx
@@ -15,51 +15,56 @@ function StaffPage() {
 			<main id={styles.main}>
 				<h1>Members of the 2022-2023 Spectator Editorial Board</h1>
 				<section id={styles.departments}>
+				<p className={styles.special_def}>* Managing Board</p>
+				<p className={styles.special_def}>** Editors-in-Training</p>
+				
 					<div>
-						<h3>Editors In Chief</h3>
+						<h3 className={styles.EIC}>Editors In Chief</h3>
 						<p>Rebecca Bao*</p>
 						<p>Phoebe Buckwalter*</p>
 					</div>
 					<div>
-						<h3>News Editors</h3>
+						<h3 className={styles.news}>News Editors</h3>
 						<p>Talia Arcasoy</p>
 						<p>Sarah Diaz*</p>
 						<p>Seth Fenton</p>
 						<p>Zoey Marcus**</p>
 					</div>
 					<div>
-						<h3>Features Editors</h3>
+						<h3 className={styles.features}>Features Editors</h3>
+						<p>Hifza Kaleem**</p>
 						<p>Dalia Levanon</p>
 						<p>Suyeon Ryu</p>
 						<p>Olivia Woo</p>
+						<p>Cathleen Xi**</p>
 					</div>
 					<div>
-						<h3>Opinions Editors</h3>
+						<h3 className={styles.ops}>Opinions Editors</h3>
 						<p>Ivy Huang*</p>
-						<p>Helen Mancini**</p>
+						<p>Helen Mancini</p>
 						<p>Gulam Monawarah</p>
-						<p>Amaryllis Sun**</p>
+						<p>Amaryllis Sun</p>
 					</div>
 					<div>
-						<h3>Science Editors</h3>
+						<h3 className={styles.science}>Science Editors</h3>
 						<p>Ryan Lin**</p>
 						<p>Hellen Luo</p>
 						<p>Michelle Ng**</p>
 						<p>Jovanna Wu</p>
 					</div>
 					<div>
-						<h3>Arts & Entertainment Editors</h3>
+						<h3 className ={styles.ae}>Arts & Entertainment Editors</h3>
 						<p>Lucien Clough</p>
 						<p>Simone Raleigh</p>
 						<p>Santino Suarez</p>
 					</div>
 					<div>
-						<h3>Humor Editors</h3>
+						<h3 className={styles.humor}>Humor Editors</h3>
 						<p>Erica Chen</p>
 						<p>Finn Charest</p>
 					</div>
 					<div>
-						<h3>Sports Editors</h3>
+						<h3 className={styles.sports}>Sports Editors</h3>
 						<p>Duncan Park**</p>
 						<p>Ava Quarles</p>
 						<p>Kaeden Ruparel</p>
@@ -67,18 +72,22 @@ function StaffPage() {
 						<p>Khush Wadhwa*</p>
 					</div>
 					<div>
-						<h3>Photography Editors</h3>
+						<h3 className={styles.photos}>Photography Editors</h3>
+						<p>Geoffrey Huang**</p>
 						<p>Lily Serry</p>
+						<p>Ryan Radwan**</p>
 						<p>Sophia Mueller</p>
+
 					</div>
 					<div>
-						<h3>Art Directors</h3>
-						<p>Jaden Bae**</p>
+						<h3 className={styles.art}>Art Directors</h3>
+						<p>Jaden Bae</p>
+						<p>Chuer Zhong**</p>
 						<p>Fareha Islam</p>
 						<p>Nelli Rojas-Cessa</p>
 					</div>
 					<div>
-						<h3>Layout Editors</h3>
+						<h3 className={styles.layout}>Layout Editors</h3>
 						<p>Ankki Dong</p>
 						<p>Fiona Huang</p>
 						<p>Elaine Liu</p>
@@ -86,7 +95,7 @@ function StaffPage() {
 						<p>Jasper Yu-Dawidowicz</p>
 					</div>
 					<div>
-						<h3>Copy Editors</h3>
+						<h3 className={styles.copy}>Copy Editors</h3>
 						<p>Kevin Chan*</p>
 						<p>Duncan Park</p>
 						<p>Ryan Park</p>
@@ -94,23 +103,20 @@ function StaffPage() {
 						<p>Allison Zhao</p>
 					</div>
 					<div>
-						<h3>Businesss Managers</h3>
+						<h3 className={styles.biz}>Business Managers</h3>
 						<p>Amber Shen</p>
 						<p>Christopher Louie</p>
 					</div>
 					<div>
-						<h3>Web Editors</h3>
+						<h3 className={styles.web}>Web Editors</h3>
 						<p>Lenny Metlitsky</p>
 						<p>Ankita Saha</p>
 					</div>
 					<div>
-						<h3>Faculty Advisor</h3>
+						<h3 className={styles.faculty}>Faculty Advisor</h3>
 						<p>Kerry Garfinkel</p>
 					</div>
 				</section>
-
-				<p className={styles.special_def}>* Managing Board</p>
-				<p className={styles.special_def}>* Editors-in-Training</p>
 			</main>
 		</>
 	);

--- a/pages/about/staff.tsx
+++ b/pages/about/staff.tsx
@@ -13,7 +13,7 @@ function StaffPage() {
 				{generateMetaTags(page_title, meta_description, meta_url)}
 			</Head>
 			<main id={styles.main}>
-				<h1>Members of the 2022-2023 Spectator Editorial Board</h1>
+				<h1>Members of the 2023-2024 Spectator Editorial Board</h1>
 				<section id={styles.departments}>
 				<p className={styles.special_def}>* Managing Board</p>
 				<p className={styles.special_def}>** Editors-in-Training</p>

--- a/styles/Staff.module.css
+++ b/styles/Staff.module.css
@@ -6,10 +6,71 @@
 	text-align: center;
 }
 
+.EIC {
+	color: rgb(215, 82, 82);
+}
+
+.news {
+	color: rgb(94, 138, 153);
+}
+
+.features {
+	color: rgb(175, 156, 86);
+}
+
+.ops {
+	color: rgb(83, 94, 180);
+}
+
+.science {
+	color: rgb(69, 147, 40);
+}
+
+.ae {
+	color: rgb(219, 101, 120);
+}
+
+.humor {
+	color: rgb(187, 187, 10);
+}
+
+.sports {
+	color: rgb(34, 181, 181);
+}
+
+.photos {
+	color: rgb(223, 150, 14);
+}
+
+.art {
+	color: rgb(145, 64, 179);
+}
+
+.layout {
+	color: rgb(134, 134, 134);
+}
+
+.copy {
+	color: rgb(176, 134, 103);
+}
+
+.biz {
+	color: rgb(82, 147, 93);
+}
+
+.web {
+	color: rgb(0, 128, 122);
+}
+
+.faculty {
+	color: rgb(154, 68, 68);
+}
+
 #main h3 {
-	margin-top: 10px;
+	margin-top: 30px;
 }
 
 .special_def {
 	text-align: right;
+	font-style: italic;
 }

--- a/styles/Staff.module.css
+++ b/styles/Staff.module.css
@@ -1,9 +1,17 @@
 #main {
 	width: 95vw;
 	max-width: 1000px;
-	padding-top: 1rem;
+	padding-block: 1rem;
 	margin: 0 auto;
 	text-align: center;
+}
+
+#departments h3 {
+	font-size: 1.6rem;
+}
+
+#departments p {
+	font-size: 1.25rem;
 }
 
 .EIC {
@@ -19,7 +27,7 @@
 }
 
 .ops {
-	color: rgb(83, 94, 180);
+	color: rgb(99, 112, 207);
 }
 
 .science {


### PR DESCRIPTION
I made the department sections clearer by designating a specific color to each department's name as well as making sure that the color appeared visible when on either light or dark mode. Furthermore, I also moved the Managing Board/Editors-in-training asterisks to the top because I thought that it would be clearer to users that way instead of at the bottom where they'll have to read all the editors' names first. Within the editors' names, I added all the new EITs who weren't on the website (the Photos and Features EITS) as well as removed asterisks from the names of former EITs who are now editors.