### PR TITLE
Change bug reporting link to open in new tab

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -296,6 +296,8 @@ const Footer = () => {
 						<Link
 							passHref
 							href="https://github.com/stuyspec/stuyspec-rewrite/issues"
+							target="_blank"
+							rel="noopener"
 						>
 							Found a bug? Report it here.
 						</Link>


### PR DESCRIPTION
Opening the bug reporting link on a new tab allows the user to go back and forth between the spec website and github more easily.