### PR TITLE
No flashing when theme is switched

### DIFF
--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,40 +1,9 @@
-import { useState, useEffect } from "react";
 import Image from "next/image";
 import styles from "../styles/Navbar.module.css";
+import { useTheme } from 'next-themes'
 
-const defaultTheme = "light";
 const ThemeToggle = () => {
-	const [theme, setTheme] = useState(getTheme());
-
-	function getTheme() {
-		if (typeof window !== "undefined") {
-			return localStorage.getItem("theme") || defaultTheme;
-		} else {
-			return defaultTheme;
-		}
-	}
-
-	useEffect(() => {
-		if (theme === "light") {
-			document.documentElement.className = "light-mode";
-			localStorage.setItem("theme", `${theme}`);
-		} else {
-			document.documentElement.className = "dark-mode";
-			localStorage.setItem("theme", `${theme}`);
-		}
-	});
-
-	function toggleTheme() {
-		if (theme === "dark") {
-			document.documentElement.className = "light-mode";
-			setTheme("light");
-			localStorage.setItem("theme", `${theme}`);
-		} else {
-			document.documentElement.className = "dark-mode";
-			setTheme("dark");
-			localStorage.setItem("theme", `${theme}`);
-		}
-	}
+	const { theme, setTheme } = useTheme();
 
 	return (
 		<>
@@ -44,7 +13,7 @@ const ThemeToggle = () => {
 					width={36}
 					alt="theme toggle button"
 					height={36}
-					onClick={toggleTheme}
+					onClick={() => setTheme('light')}
 					id={styles.colorModeToggle}
 					className="button"
 				/>
@@ -54,7 +23,7 @@ const ThemeToggle = () => {
 					width={36}
 					alt="theme toggle button"
 					height={36}
-					onClick={toggleTheme}
+					onClick={() => setTheme('dark')}
 					id={styles.colorModeToggle}
 					className="button"
 				/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 				"@typescript-eslint/eslint-plugin": "^6.7.5",
 				"mongodb": "^6.1.0",
 				"next": "^13.5.4",
+				"next-themes": "^0.2.1",
 				"node-fetch": "^3.3.2",
 				"react": "18.2.0",
 				"react-dom": "18.2.0",
@@ -3016,6 +3017,16 @@
 				"sass": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/next-themes": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.2.1.tgz",
+			"integrity": "sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==",
+			"peerDependencies": {
+				"next": "*",
+				"react": "*",
+				"react-dom": "*"
 			}
 		},
 		"node_modules/node-abi": {
@@ -6590,6 +6601,12 @@
 				"styled-jsx": "5.1.1",
 				"watchpack": "2.4.0"
 			}
+		},
+		"next-themes": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.2.1.tgz",
+			"integrity": "sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==",
+			"requires": {}
 		},
 		"node-abi": {
 			"version": "3.33.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"@typescript-eslint/eslint-plugin": "^6.7.5",
 		"mongodb": "^6.1.0",
 		"next": "^13.5.4",
+		"next-themes": "^0.2.1",
 		"node-fetch": "^3.3.2",
 		"react": "18.2.0",
 		"react-dom": "18.2.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,6 +8,7 @@ import LoadingBar from "react-top-loading-bar";
 import { generateMetaTags } from "../utils/generateMetaTags";
 import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
+import { ThemeProvider } from 'next-themes'
 
 function MyApp(props: AppProps) {
 	let { Component, pageProps } = props;
@@ -32,59 +33,61 @@ function MyApp(props: AppProps) {
 	const meta_url = "https://stuyspec.com";
 
 	return (
-		<div>
-			<Head>
-				<link rel="icon" href="/favicon.ico" />
-				<link
-					rel="apple-touch-icon"
-					sizes="180x180"
-					href="/apple-touch-icon.png?v=1.0"
-				/>
-				<link
-					rel="icon"
-					type="image/png"
-					sizes="32x32"
-					href="/favicon-32x32.png?v=1.0"
-				/>
-				<link
-					rel="icon"
-					type="image/png"
-					sizes="16x16"
-					href="/favicon-16x16.png?v=1.0"
-				/>
-				<link rel="manifest" href="/site.webmanifest?v=1.0" />
-				<link
-					rel="mask-icon"
-					href="/safari-pinned-tab.svg?v=1.0"
-					color="#5bbad5"
-				/>
-				<link rel="shortcut icon" href="/favicon.ico?v=1.0" />
-				<meta name="msapplication-TileColor" content="#da532c" />
-				<meta name="theme-color" content="#ffffff" />
-
-				{generateMetaTags(title, description, meta_url)}
-			</Head>
-			<LoadingBar
-				color='#4283e4'
-				progress={progress}
-				onLoaderFinished={() => setProgress(0)}
-				waitingTime={500}
-			/>
+		<ThemeProvider defaultTheme="light" enableSystem>
 			<div>
-				<div id="navbar">
-					<Navbar />
+				<Head>
+					<link rel="icon" href="/favicon.ico" />
+					<link
+						rel="apple-touch-icon"
+						sizes="180x180"
+						href="/apple-touch-icon.png?v=1.0"
+					/>
+					<link
+						rel="icon"
+						type="image/png"
+						sizes="32x32"
+						href="/favicon-32x32.png?v=1.0"
+					/>
+					<link
+						rel="icon"
+						type="image/png"
+						sizes="16x16"
+						href="/favicon-16x16.png?v=1.0"
+					/>
+					<link rel="manifest" href="/site.webmanifest?v=1.0" />
+					<link
+						rel="mask-icon"
+						href="/safari-pinned-tab.svg?v=1.0"
+						color="#5bbad5"
+					/>
+					<link rel="shortcut icon" href="/favicon.ico?v=1.0" />
+					<meta name="msapplication-TileColor" content="#da532c" />
+					<meta name="theme-color" content="#ffffff" />
+
+					{generateMetaTags(title, description, meta_url)}
+				</Head>
+				<LoadingBar
+					color='#4283e4'
+					progress={progress}
+					onLoaderFinished={() => setProgress(0)}
+					waitingTime={500}
+				/>
+				<div>
+					<div id="navbar">
+						<Navbar />
+					</div>
+					<div id="main">
+						<Component {...pageProps} />
+					</div>
+					<Footer />
+					<Script
+						async
+						src="https://umami.stuyspec.com/script.js"
+						data-website-id="37284781-2b87-4063-8035-5a7f3e7ab6d3"
+					></Script>
 				</div>
-				<div id="main">
-					<Component {...pageProps} />
-				</div>
-				<Footer />
-				<Script
-					async
-					src="https://umami.stuyspec.com/script.js"
-					data-website-id="37284781-2b87-4063-8035-5a7f3e7ab6d3"
-				></Script>
 			</div>
-		</div>
+		</ThemeProvider>
 	);
 }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -51,20 +51,21 @@
 	--secondary-font: "Lato";
 }
 
-.dark-mode {
-	--secondary-nav: #272525;
-	--primary: #ffffff;
-	--secondary: #2c2c2c;
-	--light-grey: #272525;
-	--medium-grey: #e9e8e8;
-}
-
-.light-mode {
+[data-theme='light'] {
+	/* Light Theme, default */
 	--secondary-nav: #2e2e2e;
 	--primary: #353637;
 	--secondary: #ffffff;
 	--light-grey: #f1f1f1;
 	--medium-grey: #555555;
+}
+[data-theme='dark'] {
+	/* Dark Theme */
+	--secondary-nav: #272525;
+	--primary: #ffffff;
+	--secondary: #2c2c2c;
+	--light-grey: #272525;
+	--medium-grey: #e9e8e8;
 }
 
 ::selection {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -49,9 +49,7 @@
 	--small-text: 1rem;
 	--primary-font: "Minion Pro", Georgia;
 	--secondary-font: "Lato";
-}
 
-[data-theme='light'] {
 	/* Light Theme, default */
 	--secondary-nav: #2e2e2e;
 	--primary: #353637;
@@ -59,6 +57,7 @@
 	--light-grey: #f1f1f1;
 	--medium-grey: #555555;
 }
+
 [data-theme='dark'] {
 	/* Dark Theme */
 	--secondary-nav: #272525;


### PR DESCRIPTION
Migrate to using ``next-themes``, a library that adds a data attribute onto the HTML, thus allowing the theme to be already visible on page load, which prevents an ugly flash.