### PR TITLE
Multiple images within an article

### DIFF
--- a/db.ts
+++ b/db.ts
@@ -33,8 +33,6 @@ async function applyTextImageCredit(
 		])
 		.toArray();
 
-	console.log("Article extras: ", article_extras);
-
 	let text = v.text;
 
 	const regex = /<div.*class=.content_img.*?>/g; // just match the opening tag of '<div class="content_img">'

--- a/pages/article/[article_slug].tsx
+++ b/pages/article/[article_slug].tsx
@@ -29,7 +29,6 @@ function Article(props: Props) {
 		contributors,
 		cover_image_summary,
 		cover_image_contributor,
-		cover_image_contributors_info,
 		cover_image_source,
 		summary,
 		slug,
@@ -141,7 +140,7 @@ function Article(props: Props) {
 								<div id={styles.coverImageContributor}>
 									By&nbsp;
 									{generate_contributors_jsx([
-										cover_image_contributors_info[0],
+										cover_image_contributor[0],
 									])}
 								</div>
 								<div>

--- a/pages/article/[article_slug].tsx
+++ b/pages/article/[article_slug].tsx
@@ -29,6 +29,7 @@ function Article(props: Props) {
 		contributors,
 		cover_image_summary,
 		cover_image_contributor,
+		cover_image_contributors_info,
 		cover_image_source,
 		summary,
 		slug,
@@ -140,7 +141,7 @@ function Article(props: Props) {
 								<div id={styles.coverImageContributor}>
 									By&nbsp;
 									{generate_contributors_jsx([
-										cover_image_contributor,
+										cover_image_contributors_info[0],
 									])}
 								</div>
 								<div>

--- a/styles/[article_slug].module.css
+++ b/styles/[article_slug].module.css
@@ -87,12 +87,19 @@
 	font-family: var(--secondary-font);
 }
 
-#coverImageContributor {
-	margin-top: -5px;
+#coverImageContributor,
+#content :global(.img_credit) {
+	text-decoration: none;
+	font-family: var(--secondary-font);
+	display: block;
 	text-align: right;
 	color: var(--medium-grey);
 	font-style: italic;
 	font-size: calc(var(--large-text) / 2.4);
+}
+
+#coverImageContributor {
+	margin-top: -5px;
 }
 
 @media screen and (max-width: 840px) {
@@ -126,4 +133,10 @@
 
 #content a {
 	text-decoration: underline;
+}
+
+#content img {
+	display: block;
+	width: 100%;
+	font-style: italic;
 }

--- a/ts_types/db_types.ts
+++ b/ts_types/db_types.ts
@@ -13,7 +13,8 @@ export interface ReceivedArticle {
 	summary: string;
 	cover_image: string;
 	cover_image_summary: string;
-	cover_image_contributor: ReceivedStaff;
+	cover_image_contributor: mongoObjectId[];
+	cover_image_contributors_info: ReceivedStaff[];
 	cover_image_source: string;
 	sub_section: string | undefined;
 	rank: number | undefined;

--- a/ts_types/db_types.ts
+++ b/ts_types/db_types.ts
@@ -13,15 +13,14 @@ export interface ReceivedArticle {
 	summary: string;
 	cover_image: string;
 	cover_image_summary: string;
-	cover_image_contributor: mongoObjectId[];
-	cover_image_contributors_info: ReceivedStaff[];
+	cover_image_contributor: ReceivedStaff[];
 	cover_image_source: string;
 	sub_section: string | undefined;
 	rank: number | undefined;
 }
 
 export interface ReceivedStaff {
-	_id: ObjectId | string;
+	_id: mongoObjectId;
 	name: string;
 	email: string;
 	position: string;
@@ -31,6 +30,15 @@ export interface ReceivedStaff {
 	years: number[];
 	slug: string;
 	first_time_login: boolean | undefined;
+}
+
+export interface ReceivedArticleExtra {
+	_id: mongoObjectId;
+	article_id: mongoObjectId;
+	contributors: ReceivedStaff[];
+	type: string;
+	index: number;
+	image_src: string;
 }
 
 export type Department =


### PR DESCRIPTION
- Multiple images within an article, with contributors being set
- Created the article_extras collection to store the relational data between the extra (image data), article, and contributor
- Added future support for more than just images being included in an article's body (graphs, videos, etc) through future article_extras
- Still server side renders the images by replacing any div in the content with ``<div class="content_img">`` with the extra at the corresponding index


Visit this demo article on the dev server after you check this PR out: http://localhost:3000/article/new-yorks-invisible-ecological-engineers